### PR TITLE
build: added theme provider and theme types

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,15 @@
+import React from 'react';
 import type { Preview } from '@storybook/react';
+import { EquityThemeProvider } from '../src/theme';
 
 const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <EquityThemeProvider>
+        <Story />
+      </EquityThemeProvider>
+    ),
+  ],
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@femmecubator/equity-ui",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,6 +1,8 @@
-import { type SVGProps } from 'react';
+import { type SVGProps, useMemo } from 'react';
 import spriteHref from '../../icons/sprite.svg';
 import type { IconName } from '../../icons/icon-constant';
+import { useTheme } from '@emotion/react';
+import { EquityTheme } from '../../theme';
 
 export const defaultIconSizes = {
   small: 18,
@@ -12,15 +14,25 @@ export type DefaultIconSizes = keyof typeof defaultIconSizes;
 const Icon = ({
   name,
   size = 'large',
+  color = 'default',
   ...props
 }: SVGProps<SVGSVGElement> & {
   name: IconName;
   size?: DefaultIconSizes | number;
+  color?: keyof EquityTheme['semantic']['color']['content'];
 }) => {
-  const actualSize = typeof size === 'string' ? defaultIconSizes[size] : size;
+  const theme = useTheme();
+
+  const actualSize = useMemo(() => {
+    return typeof size === 'string' ? defaultIconSizes[size] : size;
+  }, [size]);
+
+  const actualColor = useMemo(() => {
+    return theme.semantic?.color?.content[color] || color;
+  }, [color, theme.semantic?.color?.content]);
 
   return (
-    <svg width={actualSize} height={actualSize} {...props}>
+    <svg width={actualSize} height={actualSize} color={actualColor} {...props}>
       <use href={`${spriteHref}#${name}`} />
     </svg>
   );

--- a/src/components/Icon/__docs__/Icon.stories.tsx
+++ b/src/components/Icon/__docs__/Icon.stories.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import Icon, { defaultIconSizes, DefaultIconSizes } from '../Icon';
 import { iconList } from '../../../icons/icon-constant';
+import { theme } from '../../../theme';
 
 const iconOptions = [...iconList].sort();
 const sizeOptions = Object.keys(defaultIconSizes);
@@ -25,6 +26,10 @@ Basic.argTypes = {
   size: {
     options: sizeOptions,
     control: { type: 'radio' },
+  },
+  color: {
+    options: Object.keys(theme.semantic.color.content),
+    control: { type: 'select' },
   },
 };
 

--- a/src/theme/emotion.d.ts
+++ b/src/theme/emotion.d.ts
@@ -1,0 +1,6 @@
+import '@emotion/react';
+import type { EquityTheme } from '.';
+
+declare module '@emotion/react' {
+  export interface Theme extends EquityTheme {}
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,1 @@
+export { EquityThemeProvider, theme, type EquityTheme } from './theme';

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ThemeProvider } from '@emotion/react';
+import { base, semantic } from '../../tokens';
+
+export const theme = {
+  base,
+  semantic,
+};
+
+export type EquityTheme = typeof theme;
+
+type EquityThemeProviderProps = {
+  children: React.ReactNode;
+};
+
+export const EquityThemeProvider = ({ children }: EquityThemeProviderProps) => {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './semantic';


### PR DESCRIPTION
This PR introduces a `ThemeProvider` and a theme incorporating the created design tokens. Additionally, it modifies the icon component to accept a color property aligned with semantic colors.